### PR TITLE
Xpath and Database for Mendix 9

### DIFF
--- a/src/DataGridColumnSearch/widget/DataGridColumnSearch.js
+++ b/src/DataGridColumnSearch/widget/DataGridColumnSearch.js
@@ -94,7 +94,7 @@ define([
                     case "xpath":
                         this._dataType = "xpath";
                         break;
-                    case "database": //vdfklf
+                    case "database": // for Mendix 9
                         this._dataType = "xpath";
                         break;
                     default:

--- a/src/DataGridColumnSearch/widget/DataGridColumnSearch.js
+++ b/src/DataGridColumnSearch/widget/DataGridColumnSearch.js
@@ -94,6 +94,9 @@ define([
                     case "xpath":
                         this._dataType = "xpath";
                         break;
+                    case "database": //vdfklf
+                        this._dataType = "xpath";
+                        break;
                     default:
                         this._dataType = "unsupported";
                         break;


### PR DESCRIPTION
Tested in Mendix 9.12.4 by using Data Grid (XPath) - In javascript it was showing a type - database